### PR TITLE
Add ability to specify vip parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,19 @@ RUN apk update && \
     apk upgrade && \
     apk add --no-cache git && \
     apk add make
-RUN mkdir -p /opt/gocast
-RUN mkdir -p /go/src/github.com/mayuresh82
-RUN cd /go/src/github.com/mayuresh82 && \
-    git clone https://github.com/mayuresh82/gocast
+
+RUN mkdir -p /go/src/github.com/mayuresh82/gocast
+
+COPY . /go/src/github.com/mayuresh82/gocast
+
 WORKDIR /go/src/github.com/mayuresh82/gocast
+
 RUN make
-RUN cp gocast /opt/gocast/
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates bash iptables netcat-openbsd sudo
 WORKDIR /root/
-COPY --from=builder /opt/gocast/gocast .
+COPY --from=builder /go/src/github.com/mayuresh82/gocast .
 
 EXPOSE 8080/tcp
 

--- a/config.yaml
+++ b/config.yaml
@@ -24,4 +24,7 @@ bgp:
 apps:
   - name: app1
     vip: 1.1.1.1/32
+    vip_config:
+      # additional per VIP BGP communities
+      bgp_communities: [ aaaa:bbbb ]
     monitor: port:tcp:5000

--- a/config/config.go
+++ b/config/config.go
@@ -26,11 +26,18 @@ type BgpConfig struct {
 	Origin      string
 }
 
+type VipConfig struct {
+	// per VIP BGP communities to announce. This is in addition to the
+	// global config
+	BgpCommunities []string `yaml:"bgp_communities"`
+}
+
 type AppConfig struct {
-	Name     string
-	Vip      string
-	Monitors []string
-	Nats     []string
+	Name      string
+	Vip       string
+	VipConfig VipConfig `yaml:"vip_config"`
+	Monitors  []string
+	Nats      []string
 }
 
 type Config struct {

--- a/controller/app.go
+++ b/controller/app.go
@@ -71,6 +71,11 @@ func (a *App) Equal(other *App) bool {
 	return a.Name == other.Name && a.Vip.Net.String() == other.Vip.Net.String()
 }
 
+func (a *App) String() string {
+	return fmt.Sprintf("Name: %s, Vip: %s, VipConf: %v, Monitors: %v, Nats: %v, Source: %s",
+		a.Name, a.Vip.Net.String(), a.VipConfig, a.Monitors, a.Nats, a.Source)
+}
+
 func NewApp(appName, vip string, vipConfig config.VipConfig, monitors []string, nats []string, source string) (*App, error) {
 	if appName == "" {
 		return nil, fmt.Errorf("Invalid app name")

--- a/controller/app_test.go
+++ b/controller/app_test.go
@@ -3,32 +3,36 @@ package controller
 import (
 	"testing"
 
+	"github.com/mayuresh82/gocast/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAppParsing(t *testing.T) {
 	a := assert.New(t)
-	app1, err := NewApp("app1", "1.1.1.1/32", []string{"port:tcp:123"}, []string{}, "")
+	app1, err := NewApp("app1", "1.1.1.1/32", config.VipConfig{}, []string{"port:tcp:123"}, []string{}, "")
 	a.Nil(err)
-	app2, err := NewApp("app1", "1.1.1.1/32", []string{"port:tcp:123"}, []string{}, "")
+	app2, err := NewApp("app1", "1.1.1.1/32", config.VipConfig{BgpCommunities: []string{"111:222"}}, []string{"port:tcp:123"}, []string{}, "")
 	a.Nil(err)
-	app3, err := NewApp("app3", "2.2.2.2/32", []string{"exec:/bin/testme"}, []string{}, "")
+	app3, err := NewApp("app3", "2.2.2.2/32", config.VipConfig{}, []string{"exec:/bin/testme"}, []string{}, "")
 	a.Nil(err)
 
-	a.Equal("1.1.1.1/32", app1.Vip.String())
+	a.Equal("1.1.1.1/32", app1.Vip.Net.String())
 	a.Equal(Monitor_PORT, app1.Monitors[0].Type)
 	a.Equal("123", app1.Monitors[0].Port)
 	a.Equal("tcp", app1.Monitors[0].Protocol)
+	a.Equal(config.VipConfig{}, app1.VipConfig)
 
 	a.Equal(true, app1.Equal(app2))
+
+	a.Equal("111:222", app2.Vip.Communities[0])
 
 	a.Equal(Monitor_EXEC, app3.Monitors[0].Type)
 	a.Equal("/bin/testme", app3.Monitors[0].Cmd)
 
 	// test errors
-	_, err = NewApp("app4", "4.4.4.4", []string{}, []string{}, "")
+	_, err = NewApp("app4", "4.4.4.4", config.VipConfig{}, []string{}, []string{}, "")
 	a.NotNil(err)
 
-	_, err = NewApp("app4", "4.4.4.4/32", []string{"port:abcd::1023"}, []string{}, "")
+	_, err = NewApp("app4", "4.4.4.4/32", config.VipConfig{}, []string{"port:abcd::1023"}, []string{}, "")
 	a.NotNil(err)
 }

--- a/controller/bgp_test.go
+++ b/controller/bgp_test.go
@@ -93,7 +93,8 @@ func TestBgpNew(t *testing.T) {
 		a.FailNow(err.Error())
 	}
 	_, ipnet, _ := net.ParseCIDR("20.30.40.0/24")
-	if err := ctrl.Announce(ipnet); err != nil {
+	r := &Route{Net: ipnet}
+	if err := ctrl.Announce(r); err != nil {
 		a.FailNow(err.Error())
 	}
 

--- a/controller/consul.go
+++ b/controller/consul.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/mayuresh82/gocast/config"
 )
 
 const (
@@ -85,6 +86,7 @@ func (c *ConsulMon) queryServices() ([]*App, error) {
 			monitors []string
 			nats     []string
 		)
+		var vipConf config.VipConfig
 		for _, tag := range service.Tags {
 			// try to find the requires tags. Only vip is mandatory
 			parts := strings.Split(tag, "=")
@@ -94,6 +96,8 @@ func (c *ConsulMon) queryServices() ([]*App, error) {
 			switch parts[0] {
 			case "gocast_vip":
 				vip = parts[1]
+			case "gocast_vip_communities":
+				vipConf.BgpCommunities = strings.Split(parts[1], ",")
 			case "gocast_monitor":
 				monitors = append(monitors, parts[1])
 			case "gocast_nat":
@@ -104,7 +108,7 @@ func (c *ConsulMon) queryServices() ([]*App, error) {
 			glog.Errorf("No vip Tag found in matched service :%s", service.Service)
 			continue
 		}
-		app, err := NewApp(service.Service, vip, monitors, nats, "consul")
+		app, err := NewApp(service.Service, vip, vipConf, monitors, nats, "consul")
 		if err != nil {
 			glog.Errorf("Unable to add consul app: %v", err)
 			continue

--- a/controller/consul_test.go
+++ b/controller/consul_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/mayuresh82/gocast/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +16,7 @@ var mockConsulData = map[string]string{
 			"ID": "test-app-1",
 			"Service": "test-service",
 			"Tags": [
-				"enable_gocast", "gocast_vip=1.1.1.1/32", "gocast_monitor=consul"
+				"enable_gocast", "gocast_vip=1.1.1.1/32", "gocast_monitor=consul", "gocast_vip_communities=111:222,333:444"
 			]
 		}
 	}}`,
@@ -103,7 +104,9 @@ func TestQueryServices(t *testing.T) {
 		a.FailNow(err.Error())
 	}
 	a.Equal(1, len(apps))
-	app, _ := NewApp("test-service", "1.1.1.1/32", []string{"consul"}, []string{}, "consul")
+	a.Equal([]string{"111:222", "333:444"}, apps[0].Vip.Communities)
+
+	app, _ := NewApp("test-service", "1.1.1.1/32", config.VipConfig{}, []string{"consul"}, []string{}, "consul")
 	a.True(app.Equal(apps[0]))
 
 	// test no match

--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -168,7 +168,7 @@ func (m *MonitorMgr) Add(app *App) {
 	appMon := &appMon{app: app, done: make(chan bool)}
 	m.monitors[app.Name] = appMon
 	go m.runLoop(appMon)
-	glog.Infof("Registered a new app: %v", app)
+	glog.Infof("Registered a new app: %v", app.String())
 }
 
 // Remove removes an app from monitor manager, stops BGP

--- a/server/server.go
+++ b/server/server.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/mayuresh82/gocast/controller"
 	"net/http"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/mayuresh82/gocast/config"
+	"github.com/mayuresh82/gocast/controller"
 )
 
 // Server is the main entrypoint into the app and serves app requests
@@ -46,7 +49,11 @@ func (s *Server) Serve(ctx context.Context) {
 
 func (s *Server) registerHandler(w http.ResponseWriter, r *http.Request) {
 	queries := r.URL.Query()
-	app, err := controller.NewApp(queries["name"][0], queries["vip"][0], queries["monitor"], queries["nat"], "http")
+	var vipConf config.VipConfig
+	if vipComm, ok := queries["vip_communities"]; ok {
+		vipConf.BgpCommunities = strings.Split(vipComm[0], ",")
+	}
+	app, err := controller.NewApp(queries["name"][0], queries["vip"][0], vipConf, queries["monitor"], queries["nat"], "http")
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid request: %v", err), http.StatusBadRequest)
 		return


### PR DESCRIPTION
It is a common use case to be able to announce specific VIPs with specific BGP parameters , for e.g separate bgp communities per VIP. This PR makes that possible by allowing a vip config to be added to the apps config or to consul tags.

test output:
```
?   	github.com/mayuresh82/gocast	[no test files]
?   	github.com/mayuresh82/gocast/config	[no test files]
=== RUN   TestAppParsing
--- PASS: TestAppParsing (0.00s)
=== RUN   TestBgpNew
time="2021-05-13T20:31:23-07:00" level=info msg="Add a peer configuration for:127.0.0.1" Topic=Peer
time="2021-05-13T20:31:23-07:00" level=info msg="Add a peer configuration for:127.0.0.1" Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="setting ttl for active connection is not supported" Key="127.0.0.1:179" Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Peer Up" Key=127.0.0.1 State=BGP_FSM_OPENCONFIRM Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Peer Up" Key=127.0.0.1 State=BGP_FSM_OPENCONFIRM Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Neighbor shutdown" Key=127.0.0.1 Topic=Operation
time="2021-05-13T20:31:30-07:00" level=info msg="Delete a peer configuration for:127.0.0.1" Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="sent notification" Code=6 Communicated-Reason= Data="[]" Key=127.0.0.1 State=BGP_FSM_ESTABLISHED Subcode=2 Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Peer Down" Key=127.0.0.1 Reason=dying State=BGP_FSM_ESTABLISHED Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="received notification" Code=6 Communicated-Reason= Data="[]" Key=127.0.0.1 Subcode=2 Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="failed to unset md5: setting md5 is not supported" Key=127.0.0.1 Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Delete a peer configuration for:127.0.0.1" Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="received notification" Code=6 Data="[]" Key=127.0.0.1 Subcode=3 Topic=Peer
time="2021-05-13T20:31:30-07:00" level=warning msg="Failed to AcceptTCP" Error="accept tcp4 0.0.0.0:179: use of closed network connection" Topic=Peer
time="2021-05-13T20:31:30-07:00" level=info msg="Peer Down" Key=127.0.0.1 Reason="notification-received code 6(cease) subcode 2(administrative shutdown)" State=BGP_FSM_ESTABLISHED Topic=Peer
--- PASS: TestBgpNew (7.01s)
time="2021-05-13T20:31:30-07:00" level=warning msg="Failed to AcceptTCP" Error="accept tcp6 [::]:179: use of closed network connection" Topic=Peer
=== RUN   TestQueryServices
E0513 20:31:30.306956   58203 consul.go:108] No vip Tag found in matched service :test-service
--- PASS: TestQueryServices (0.01s)
=== RUN   TestHealthCheck
--- PASS: TestHealthCheck (0.00s)
=== RUN   TestPortMonitor
--- PASS: TestPortMonitor (0.00s)
=== RUN   TestExecMonitor
--- PASS: TestExecMonitor (0.01s)
=== RUN   TestGateway
--- PASS: TestGateway (0.02s)
=== RUN   TestVia
--- PASS: TestVia (0.04s)
=== RUN   TestAddLoopback
--- PASS: TestAddLoopback (0.07s)
PASS
ok  	github.com/mayuresh82/gocast/controller	7.169s
?   	github.com/mayuresh82/gocast/server	[no test files]
```