### PR TITLE
attempt to fix a race condition

### DIFF
--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -332,6 +332,7 @@ func (m *MonitorMgr) Cleanup(app string, exit chan bool) {
 		case <-t.C:
 			glog.Infof("Cleaning up app %s", app)
 			m.Remove(app)
+			return
 		case <-exit:
 			return
 		}


### PR DESCRIPTION
There can sometimes be a race condition where an gocast attempts to clean up an app and calls Remove(), remove tries to close the runloop by sending on the done channel, but the runloop does not exist because it has been already removed.
This PR attempts to fix that by marking the runloopOn (previously checkOn) as false when the runloop exits, so that Remove() will not attempt to close it again.
Also in the Add() app function if the app already exists but its runLoop is closed , it restarts the loop.