### PR TITLE
add support for consul token auth

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,8 @@ agent:
   consul_addr: https://consul
   # interval to query consul for app discovery
   consul_query_interval: 5m
+  # token to authenticate client if consul requires it
+  consul_token: 00000000-0000-0000-0000-000000000000
 
 bgp:
   local_as: 12345

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type AgentConfig struct {
 	CleanupTimer        time.Duration `yaml:"cleanup_timer"`
 	ConsulAddr          string        `yaml:"consul_addr"`
 	ConsulQueryInterval time.Duration `yaml:"consul_query_interval"`
+	ConsulToken			string		  `yaml:"consul_token"`
 }
 
 type BgpConfig struct {

--- a/controller/consul.go
+++ b/controller/consul.go
@@ -85,6 +85,9 @@ func (c *ConsulMon) queryServices() ([]*App, error) {
 	}
 	addr := c.addr + fmt.Sprintf("%s/%s?%s", nodeURL, c.node, stale)
 	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	if err != nil {
+		return apps, err
+	}
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return apps, err
@@ -143,6 +146,9 @@ func (c *ConsulMon) healthCheckLocal(service string) (bool, error) {
 	params.Add("filter", "enable_gocast in ServiceTags")
 	addr := c.addr + fmt.Sprintf("%s?%s", localHealthCheckurl, params.Encode())
 	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	if err != nil {
+		return false, err
+	}
 	resp, err := c.client.Do(req)
 	if err != nil {
 		glog.V(2).Infof("Error getting %s with %s", addr, err)
@@ -172,6 +178,9 @@ func (c *ConsulMon) healthCheckLocal(service string) (bool, error) {
 func (c *ConsulMon) healthCheckRemote(service string) (bool, error) {
 	addr := c.addr + fmt.Sprintf("%s/%s", remoteHealthCheckurl, service)
 	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	if err != nil {
+		return false, err
+	}
 	resp, err := c.client.Do(req)
 	if err != nil {
 		glog.V(2).Infof("Error getting %s with %s", addr, err)

--- a/controller/consul.go
+++ b/controller/consul.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	consulNodeEnv        = "CONSUL_NODE"
+	consulToken          = "CONSUL_TOKEN"
 	allowStale           = "CONSUL_STALE"
 	matchTag             = "enable_gocast"
 	nodeURL              = "/catalog/node"
@@ -23,7 +24,7 @@ const (
 )
 
 type Clienter interface {
-	Get(url string) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
 }
 
 type Client struct {
@@ -32,6 +33,7 @@ type Client struct {
 
 type ConsulMon struct {
 	addr   string
+	token  string
 	node   string
 	client Clienter
 }
@@ -53,12 +55,26 @@ func contains(inp []string, elem string) bool {
 	return false
 }
 
-func NewConsulMon(addr string) (*ConsulMon, error) {
+func NewConsulMon(addr string, token string) (*ConsulMon, error) {
 	node := os.Getenv(consulNodeEnv)
 	if node == "" {
 		return nil, fmt.Errorf("%s env variable not set", consulNodeEnv)
 	}
-	return &ConsulMon{addr: addr, node: node, client: &http.Client{Timeout: 10 * time.Second}}, nil
+	return &ConsulMon{addr: addr, token: token, node: node, client: &http.Client{Timeout: 10 * time.Second}}, nil
+}
+
+func getHTTPReq(httpMethod string, addr string, tokenFrmCfg string) (*http.Request, error) {
+	req, err := http.NewRequest(httpMethod, addr, nil)
+	if err != nil {
+		return nil, err
+	}
+	tokenFrmEnv := os.Getenv(consulToken)
+	if tokenFrmEnv != "" {
+		req.Header.Set("X-Consul-Token", tokenFrmEnv)
+	} else if tokenFrmCfg != "" {
+		req.Header.Set("X-Consul-Token", tokenFrmCfg)
+	}
+	return req, nil
 }
 
 func (c *ConsulMon) queryServices() ([]*App, error) {
@@ -68,7 +84,8 @@ func (c *ConsulMon) queryServices() ([]*App, error) {
 		stale = "stale"
 	}
 	addr := c.addr + fmt.Sprintf("%s/%s?%s", nodeURL, c.node, stale)
-	resp, err := c.client.Get(addr)
+	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return apps, err
 	}
@@ -125,7 +142,8 @@ func (c *ConsulMon) healthCheckLocal(service string) (bool, error) {
 	params := url.Values{}
 	params.Add("filter", "enable_gocast in ServiceTags")
 	addr := c.addr + fmt.Sprintf("%s?%s", localHealthCheckurl, params.Encode())
-	resp, err := c.client.Get(addr)
+	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		glog.V(2).Infof("Error getting %s with %s", addr, err)
 		return false, err
@@ -153,7 +171,8 @@ func (c *ConsulMon) healthCheckLocal(service string) (bool, error) {
 // This is the underlying api call: https://www.consul.io/api/health.html
 func (c *ConsulMon) healthCheckRemote(service string) (bool, error) {
 	addr := c.addr + fmt.Sprintf("%s/%s", remoteHealthCheckurl, service)
-	resp, err := c.client.Get(addr)
+	req, err := getHTTPReq(http.MethodGet, addr, c.token)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		glog.V(2).Infof("Error getting %s with %s", addr, err)
 		return false, err

--- a/controller/monitor.go
+++ b/controller/monitor.go
@@ -84,7 +84,7 @@ func NewMonitor(config *c.Config) *MonitorMgr {
 		cleanups: make(map[string]chan bool),
 	}
 	if config.Agent.ConsulAddr != "" {
-		cmon, err := NewConsulMon(config.Agent.ConsulAddr)
+		cmon, err := NewConsulMon(config.Agent.ConsulAddr, config.Agent.ConsulToken)
 		if err != nil {
 			glog.Errorf("Failed to start consul monitor: %v", err)
 		} else {


### PR DESCRIPTION
This PR adds support to authenticate the consul client using token.

If consul agent needs authentication for API calls, gocast needs to provide a token in the header of consul API calls.

Ways to Provide token:
1) You can have the token defined in gocast config file i.e config.yaml.
2) You can define token in an environment variable (CONSUL_TOKEN). This will precede over token defined in config file

If consul agent doesn't need a token, then you can skip the token field from config file and environment variable

```
./gocast -logtostderr -v=2 -config config.yaml
I0822 12:19:36.675860   34350 server.go:29] Starting http server on :8080
I0822 12:19:36.677301   34350 app.go:108] Will use consul healthcheck monitor
I0822 12:19:36.677335   34350 monitor.go:182] Registered a new app: Name: httpd, Vip: 10.255.255.1/32, VipConf: {[]}, Monitors: [0xc0004b41c0], Nats: [], Source: consul
I0822 12:19:36.677365   34350 monitor.go:296] Starting run-loop for app httpd
I0822 12:19:36.677789   34350 monitor.go:250] All Monitors for app: httpd succeeded
```