### PR TITLE
Update config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -29,4 +29,5 @@ apps:
     vip_config:
       # additional per VIP BGP communities
       bgp_communities: [ aaaa:bbbb ]
-    monitor: port:tcp:5000
+    monitors: 
+      - port:tcp:5000


### PR DESCRIPTION
the monitor key needs to be plural, and it's values need to be a list in order for the monitors to correctly execute. This change updates the example config to reflect this.